### PR TITLE
Fixed #1 and testing on CSS with quoted value

### DIFF
--- a/Website/App_Start/StyleBundleExtensions.cs
+++ b/Website/App_Start/StyleBundleExtensions.cs
@@ -66,17 +66,20 @@ namespace Website
                 }}()", bundle.CdnPath, fallback) :
 
                 String.Format(@"function() {{
-                var loadFallback,
-                    len = document.styleSheets.length;
+                var len = document.styleSheets.length;
+                //console.log(""## Testing fallback for {0}"");
                 for (var i = 0; i < len; i++) {{
                     var sheet = document.styleSheets[i];
-                    if (sheet.href.indexOf('{0}') !== -1) {{
+                    if (sheet.href && sheet.href.indexOf('{0}') !== -1) {{
                         var meta = document.createElement('meta');
                         meta.className = '{2}';
                         document.head.appendChild(meta);
                         var value = window.getComputedStyle(meta).getPropertyValue('{3}');
                         document.head.removeChild(meta);
-                        if (value !== '{4}') {{
+                        //console.log(""Comparing: "" + value)
+                        //console.log(""To:        {4}"")
+                        if (value !== ""{4}"") {{
+                            //console.log(""Fallback on CSS: "" + ""{1}"");
                             document.write('<link href=""{1}"" rel=""stylesheet"" type=""text/css"" />');
                         }}
                     }}


### PR DESCRIPTION
Too check for bootstrap I tried checking for glyphicons like so:

```
        StyleBundle bootstrapStyle = new StyleBundle("~/css/bootstrap", "//maxcdn.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css");
        bootstrapStyle.IncludeFallback("~/Content/bootstrap.css",
            className: "glyphicon",
            ruleName: "font-family",
            ruleValue: "'Glyphicons Halflings'" // Quotes in this string are necessary
            );
        bundles.Add(bootstrapStyle);
```

Notice that the ruleValue has quotes as a part of the string.
